### PR TITLE
Mark `customView` as public

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -128,7 +128,7 @@ open class BaseNotificationBanner: UIView {
     internal var spacerView: UIView!
 
     // The custom view inside the notification banner
-    internal var customView: UIView?
+    public internal(set) var customView: UIView?
 
     /// The default offset for spacerView top or bottom
     internal var spacerViewDefaultOffset: CGFloat = 10.0


### PR DESCRIPTION
We need a way to get the `customView` back in some event delegate methods. However, it is now an `internal` property, which limits this possibility.